### PR TITLE
docs: [SM] Update prompt-log.md (Entry 5), decision-log.md (Entries #1–5), and add Week 1 standup notes 

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1,0 +1,19 @@
+# Decision Log
+**Project:** Syllabus & Curriculum Map (Knowledge Mapping)  
+**Role:** Project Manager (Scrum Master)  
+**Last updated:** 2026-03-31
+
+Every major team decision is recorded here (as required in guideline Part 2.4).
+
+| # | Date     | Decision Made                                      | Options Considered                                      | Who Was Consulted     | Outcome / Rationale |
+|---|----------|----------------------------------------------------|---------------------------------------------------------|-----------------------|---------------------|
+| 1 | 03/24/2026 | Project scope and core concept: Role-based Syllabus & Curriculum Map using Knowledge Mapping (per year / per semester focus) | 1. Generic knowledge base<br>2. Full course management system with enrollment<br>3. Focused visual curriculum knowledge map with role-based access | All team members (kickoff meeting) | Chose #3 – Focused visual curriculum knowledge map with clear role-based system (Super Admin, Admin, Faculty, Student). Matches assigned project category and keeps scope realistic for 8-week timeline. |
+| 2 | 03/24/2026 | Database: Supabase (NoSQL) as the backend database | Supabase vs Firebase/Firestore                          | All team members      | Chose Supabase – better free tier, easier real-time capabilities, and stronger integration with Vercel hosting. Directly supports knowledge mapping features (prerequisites, skills, curriculum nodes). |
+| 3 | 03/24/2026 | Role-based access control system (Super Admin, Admin, Faculty, Student) | 1. Single user type<br>2. Role-based permissions with different dashboards | All team members      | Chose role-based system. Super Admin can manage admins + audit trail; Admin manages users; Faculty handles curriculum; Student has dedicated dashboard. This directly supports KM principles of knowledge capture, sharing, and access control. |
+| 4 | 03/24/2026 | Branching strategy: Feature branches per role → PR reviews → merge to main (protected) | 1. Direct commits to main<br>2. Feature branches with mandatory PR review | All team members      | Chose feature branches per role (feature/pm, feature/developer, etc.) with protected main branch. Enforces guideline 2.1 (no direct commits to main, at least one PR per sprint). |
+| 5 | 03/24/2026 | Sprint structure and milestones created (Kickoff, Discovery, Design, Build Sprint 1, Build Sprint 2 + Polish, Deployment & Defense) | Ad-hoc weekly tasks vs structured 8-week milestones with sprints | All team members      | Created full milestone structure in GitHub Issues + Projects board. Aligns exactly with guideline Part 1 timeline and enables clear tracking of velocity and story points starting next week. |
+
+**Next major decisions to be logged (already in To Do):**  
+- Final frontend framework confirmation  
+- Vercel hosting configuration  
+- User stories template and BPMN Diagram approval

--- a/prompt-log.md
+++ b/prompt-log.md
@@ -1,0 +1,113 @@
+# Prompt Log – Scrum Master (Nerecina, John Lian R.)
+**Project:** Syllabus & Curriculum Map (Knowledge Mapping)  
+**Branch:** feature/sm  
+**Role:** Scrum Master
+
+## Entry 1
+**Date:** 2026-03-31  
+**Task:** Create complete step-by-step execution plan and outline for PM role from Day 1 to deployment.
+
+**Prompt given to AI:**  
+"Help me to make an outline to all of things that I need to do to become an effective scrum master for our group project. Our project is Syllabus & Curriculum Map."
+
+**What the AI produced:**  
+A detailed 8-week phased outline with exact deliverables, checklists, GitHub setup steps, Decision Log examples, and PM-specific tips.
+
+**What I changed / improved:**  
+I shortened some sections and made the language more precise and actionable for our team. I also added the exact milestone names from the guideline (Kickoff, Discovery, etc.).
+
+**Why:**  
+To make it easier for me to follow daily and to share cleanly with the team without overwhelming them.
+
+**What I learned / decided:**  
+I learned that breaking the guideline into weekly + daily actions makes the PM role much clearer. Decided to use this outline as my personal checklist and update it weekly.
+
+---
+
+## Entry 2
+**Date:** 2026-03-31  
+**Task:** Get precise instructions for protecting main branch and creating GitHub Projects board + milestones.
+
+**Prompt given to AI:**  
+"Make the instruction more precise... Protect the main branch" and later "Create for me an update for 1st decision-log.md" and "Instruct me step by step to create a milestone structure."
+
+**What the AI produced:**  
+Exact 10-step instructions for branch protection, full Projects board creation steps, milestone structure with titles and descriptions, and ready-to-copy Decision Log entry #1.
+
+**What I changed / improved:**  
+I followed the steps exactly but adjusted due dates to match our actual timeline (March–May 2026).
+
+**Why:**  
+The AI gave general steps; I made them specific to our repo name and current dates so there is zero confusion when I execute them.
+
+**What I learned / decided:**  
+GitHub’s interface changes slightly over time, so detailed button-by-button instructions are essential. Decided to document every setup step in this log for the oral defense.
+
+---
+
+## Entry 3
+**Date:** 2026-03-31  
+**Task:** Draft professional Week 1 update message for group chat.
+
+**Prompt given to AI:**  
+"Make me a week 1 short message for our gc about the current update of week 1." + follow-up requests to adjust tone and add scheduling for first standup.
+
+**What the AI produced:**  
+Multiple versions of the GC message with updates on repo, board, Decision Log, and call for availability.
+
+**What I changed / improved:**  
+Combined the best parts: kept it conversational but professional, added the “What’s next this week” bullet list exactly as requested.
+
+**Why:**  
+To make the message natural for our team while still sounding like a PM.
+
+**What I learned / decided:**  
+Clear, short GC messages keep everyone aligned without spamming. Decided to send one every Monday after standup.
+
+---
+
+## Entry 4
+**Date:** 2026-03-31  
+**Task:** Prepare first commit message and prompt-log.md template.
+
+**Prompt given to AI:**  
+"Make me a commit message for this: [list of folders and files]" and "Create for me an update for 1st decision-log.md" and current request for prompt-log.md.
+
+**What the AI produced:**  
+Ready-to-copy commit messages and full prompt-log.md content with proper format.
+
+**What I changed / rejected:**  
+Kept everything as provided — no major changes needed.
+
+**Why:**  
+The outputs already perfectly matched the guideline’s 5-point structure.
+
+**What I learned / decided:**  
+Using AI for documentation and communication saves time, but I must always review and own the final version. This log itself proves I understand every decision.
+
+---
+
+## Entry 5
+**Date:** 2026-03-31  
+**Task:** Turn raw meeting notes from 03/24/2026 kickoff into official Week 1 standup note + update Decision Log / prompt log structure.
+
+**Prompt given to AI (summary):**  
+"Create me this 2 mds: 2.2 The Prompt Log ... 2.3 Weekly Standup ... These are the contents of our meeting: [full raw notes including decisions on Supabase, roles, tasks, sprints, etc.]"
+
+**What the AI produced:**  
+Two complete, ready-to-copy Markdown files: one prompt-log.md entry and one properly formatted standup note following the exact guideline structure.
+
+**What I changed / improved:**  
+- Added the exact 5-point format required by the guideline.  
+- Made the standup note clearer by organizing per-role tasks and linking decisions to the Decision Log.  
+- Removed informal abbreviations and turned bullet points into professional “Completed / This week / Blockers” format.
+
+**Why:**  
+The raw notes were messy and not in the guideline format. I restructured them so they are readable for the instructor during oral defense and match the required “What I completed / What I am working on / Blockers” structure.
+
+**What I learned / decided:**  
+Raw meeting notes must be turned into formal deliverables immediately. Decided to always process standup notes within 24 hours and link them to Decision Log entries (Supabase, role-based access, Vercel, etc.). This proves I own the documentation process as PM.
+
+---
+
+**Next entries will be added as I continue using AI for standup notes, presentation slides, or other SM tasks.**


### PR DESCRIPTION
Update prompt-log.md (Entry 5), decision-log.md (Entries #1–5), and add Week 1 standup notes (/docs/standups/week1-kickoff.md) — fully document 03/24/2026 kickoff meeting decisions (Supabase, role-based system, sprint structure, branching strategy) with role-by-role reports, action items, and next-week agenda per guideline Part 2.2, 2.3 & 2.4